### PR TITLE
twitterのOGPのpath変更

### DIFF
--- a/src/components/molecules/PageHead.tsx
+++ b/src/components/molecules/PageHead.tsx
@@ -20,7 +20,7 @@ const PageHead: VFC<Props> = ({ title = 'Nabelog', description = 'Nabeoの自己
       <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       <meta name='twitter:card' content='summary_large_image' />
       <meta name='twitter:description' content={description} />
-      <meta name='twitter:image' content='/img/favicon.png' />
+      <meta name='twitter:image' content='/public/img/favicon.png' />
       <link rel='icon' href='/img/favicon.png' />
       <link rel='apple-touch-icon' href='/img/favicon.png' />
     </Head>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

Closes #68 

## 概要
twitterのOGP画像が表示されない
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

### 変更内容
twitterのOGPのpathを絶対パスへ変更
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

### 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

### 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

### 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
